### PR TITLE
add the ability to customize the auditable type

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -6,12 +6,14 @@ module Audited
     end
 
     module ClassMethods
+
       def setup_audit
         belongs_to :auditable,  :polymorphic => true
         belongs_to :user,       :polymorphic => true
         belongs_to :associated, :polymorphic => true
 
         before_create :set_version_number, :set_audit_user, :set_request_uuid
+        after_create :update_auditable_type
 
         cattr_accessor :audited_class_names
         self.audited_class_names = Set.new
@@ -87,7 +89,7 @@ module Audited
     def set_version_number
       max = self.class.where(
         :auditable_id => auditable_id,
-        :auditable_type => auditable_type
+        :auditable_type => auditable_type.constantize.try(:auditable_type) || auditable_type
       ).order(:version.desc).first.try(:version) || 0
       self.version = max + 1
     end
@@ -100,5 +102,11 @@ module Audited
     def set_request_uuid
       self.request_uuid ||= SecureRandom.uuid
     end
+
+    def update_auditable_type
+      custom = auditable_type.constantize.try(:auditable_type)
+      update_attributes(auditable_type: custom) if custom
+    end
+
   end
 end

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -225,6 +225,8 @@ module Audited
     end # InstanceMethods
 
     module AuditedClassMethods
+      attr_accessor :auditable_type
+
       # Returns an array of columns that are audited. See non_audited_columns
       def audited_columns
         self.columns.select { |c| !non_audited_columns.include?(c.name) }


### PR DESCRIPTION
If you have a different project writing in the same models, the model class may have a different name. This pull request add the ability to write the audit with the right auditable_type.
